### PR TITLE
Adding change password link to login page

### DIFF
--- a/apps/Wallet/src/app/login/page.tsx
+++ b/apps/Wallet/src/app/login/page.tsx
@@ -91,6 +91,20 @@ export default function Login() {
           >
             Login with Google
           </Button>
+          <Typography
+            variant="body1"
+            color="primary.light"
+            sx={{ maxWidth: 500 }}
+          >
+            Was your password compromised? Click here to {" "}
+            <Link
+              href="https://myaccount.google.com/intro/signinoptions/password"
+              target="_blank"
+              color="secondary"
+            >
+              change your password
+            </Link>
+          </Typography>
         </Stack>
       </Grid>
       <Grid


### PR DESCRIPTION
Added a link to google to change the user password if the user wants to do that on the login page
tested with new password, same publicKey is returned (so same web3auth account)